### PR TITLE
Fix link to active note not working

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ joplin.plugins.register({
 			execute: async () => {
 
 				const note = await joplin.workspace.selectedNote();
-				navigator.clipboard.writeText(`[${note.title}](:/${note.id})`)
+				joplin.clipboard.writeText(`[${note.title}](:/${note.id})`)
 			}
 		})
 		await joplin.views.menuItems.create('getActiveNoteLinkMenu', 'getActiveNoteLink', MenuItemLocation.EditorContextMenu);


### PR DESCRIPTION
See this discussion: https://discourse.joplinapp.org/t/copy-markdown-link-to-active-note/14402

Changed from navigator.clipboard to joplin.clipboard and it seems to work for me now